### PR TITLE
Restore `io.grpc` package name to match version pushed to Maven Central

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile 'io.grpc:grpc-core:1.10.0'
-    apt 'io.grpc.tools:grpc-java-api-checker:1.0-SNAPSHOT'
+    apt 'io.grpc:grpc-java-api-checker:1.0-SNAPSHOT'
 }
 
 configurations.errorprone {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,7 +28,7 @@
           <target>1.8</target>
           <annotationProcessorPaths>
             <path>
-              <groupId>io.grpc.tools</groupId>
+              <groupId>io.grpc</groupId>
               <artifactId>grpc-java-api-checker</artifactId>
               <version>1.0-SNAPSHOT</version>
             </path>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.grpc.tools</groupId>
+  <groupId>io.grpc</groupId>
   <artifactId>grpc-java-api-checker</artifactId>
   <version>1.0.0</version>
 

--- a/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.tools.checkers;
+package io.grpc.annotations.checkers;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.errorprone.matchers.Description.NO_MATCH;

--- a/src/main/java/io/grpc/annotations/checkers/ExperimentalApiChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/ExperimentalApiChecker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.tools.checkers;
+package io.grpc.annotations.checkers;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;

--- a/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.tools.checkers;
+package io.grpc.annotations.checkers;
 
 import com.google.auto.service.AutoService;
 import com.google.errorprone.BugPattern;

--- a/src/test/java/io/grpc/annotations/checkers/InternalCheckerTest.java
+++ b/src/test/java/io/grpc/annotations/checkers/InternalCheckerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.tools.checkers;
+package io.grpc.annotations.checkers;
 
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.Before;
@@ -23,18 +23,16 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class ExperimentalApiCheckerTest {
-
+public class InternalCheckerTest {
   private CompilationTestHelper compiler;
 
   @Before
   public void setUp() {
-    compiler = CompilationTestHelper.newInstance(ExperimentalApiChecker.class, getClass());
+    compiler = CompilationTestHelper.newInstance(InternalChecker.class, getClass());
 
-    // add the @ExperimentalApi annotation
-    compiler.addSourceLines("io/grpc/ExperimentalApi.java",
+    // add the @Internal annotation
+    compiler.addSourceLines("io/grpc/Internal.java",
         "package io.grpc;",
-        "",
         "import java.lang.annotation.Documented;",
         "import java.lang.annotation.ElementType;",
         "import java.lang.annotation.Retention;",
@@ -43,24 +41,22 @@ public class ExperimentalApiCheckerTest {
         "",
         "@Retention(RetentionPolicy.CLASS)",
         "@Target({",
-        "   ElementType.ANNOTATION_TYPE,",
-        "   ElementType.CONSTRUCTOR,",
-        "   ElementType.FIELD,",
-        "   ElementType.METHOD,",
-        "   ElementType.PACKAGE,",
-        "   ElementType.TYPE})",
+        "  ElementType.ANNOTATION_TYPE,",
+        "  ElementType.CONSTRUCTOR,",
+        "  ElementType.FIELD,",
+        "  ElementType.METHOD,",
+        "  ElementType.PACKAGE,",
+        "  ElementType.TYPE})",
         "@Documented",
-        "public @interface ExperimentalApi {",
-        "  String value() default \"\";",
-        "}");
+        "public @interface Internal {}");
 
     // add an annotated class
     compiler.addSourceLines("io/grpc/AnnotatedClass.java",
         "package io.grpc;",
         "",
-        "import io.grpc.ExperimentalApi;",
+        "import io.grpc.Internal;",
         "",
-        "@ExperimentalApi(\"https://example.com/issue\")",
+        "@Internal",
         "public class AnnotatedClass {",
         "  public static final int MEMBER = 42;",
         "  public static int foo() { return 42; }",
@@ -78,20 +74,20 @@ public class ExperimentalApiCheckerTest {
     compiler.addSourceLines("io/grpc/AnnotatedMember.java",
         "package io.grpc;",
         "",
-        "import io.grpc.ExperimentalApi;",
+        "import io.grpc.Internal;",
         "",
         "public class AnnotatedMember {",
-        "  @ExperimentalApi",
+        "  @Internal",
         "  public void instanceMethod() {}",
         "",
-        "  @ExperimentalApi",
+        "  @Internal",
         "  public static int MEMBER = 42;",
         "",
-        "  @ExperimentalApi",
+        "  @Internal",
         "  public static void staticMethod() {};",
         "",
         "",
-        "  @ExperimentalApi",
+        "  @Internal",
         "  public final int member = 42;",
         "}");
 
@@ -99,9 +95,9 @@ public class ExperimentalApiCheckerTest {
     compiler.addSourceLines("io/grpc/IAnnotated.java",
         "package io.grpc;",
         "",
-        "import io.grpc.ExperimentalApi;",
+        "import io.grpc.Internal;",
         "",
-        "@ExperimentalApi",
+        "@Internal",
         "public interface IAnnotated {",
         "}");
   }
@@ -155,7 +151,7 @@ public class ExperimentalApiCheckerTest {
   }
 
   @Test
-  public void positiveInstantiationAndCaptureDescriptionLinkUrl() {
+  public void positiveInstantiation() {
     compiler
         .addSourceLines("example/Test.java",
             "package example;",
@@ -165,7 +161,7 @@ public class ExperimentalApiCheckerTest {
             "",
             "public class Test {",
             "  public static void main(String[] args) {",
-            "    // BUG: Diagnostic contains: https://example.com/issue",
+            "    // BUG: Diagnostic contains: ",
             "    new AnnotatedClass();",
             "  }",
             "}")


### PR DESCRIPTION
Cleaning up after I ended up publishing the old v1.0.0 release tag (pointing to e98e7f15a951430cd31d80375af9320d9990e6bb, with the `io.grpc` group name) to Maven.

*****************************

Revert "bump version to 1.0.0 (#9)"

This reverts commit 95395410790dcc9ae05a861f218eff7cc11d59d9.

Revert "change groupid to `io.grpc.tools` (#7)"

This reverts commit 915b3d1c5663766e4318106d66fb2069623e8c60.

Revert "Revert "Bump version to 1.0.0 (#4)" (#6)"

This reverts commit 5705da71af55b5d3637145cfd7a1105e72ce702c.