### PR TITLE
Use top-level super method to determine annotation for @Internal apis

### DIFF
--- a/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
@@ -38,13 +38,18 @@ abstract class AnnotationChecker extends BugChecker implements IdentifierTreeMat
 
   private final String annotationType;
 
-  // When this is set to true, method calls will look for an annotation on the top-level method
-  // declaration. This is used to avoid io.grpc.internal implementations "hiding" publicly declared
-  // API methods.
-  protected boolean checkTopOfMethodHierarchy = false;
+  // When this is set to true, method calls will only match the annotation if all members of the
+  // method hierarchy are annotated. This is used to avoid io.grpc.internal implementations
+  // "hiding" publicly declared API methods.
+  private final boolean requireAnnotationOnMethodHierarchy;
 
   AnnotationChecker(String annotationType) {
+    this(annotationType, false);
+  }
+
+  AnnotationChecker(String annotationType, boolean requireAnnotationOnMethodHierarchy) {
     this.annotationType = checkNotNull(annotationType, "annotationType");
+    this.requireAnnotationOnMethodHierarchy = requireAnnotationOnMethodHierarchy;
   }
 
   /**
@@ -71,18 +76,19 @@ abstract class AnnotationChecker extends BugChecker implements IdentifierTreeMat
     if (symbol == null) {
       return NO_MATCH;
     }
-    if (checkTopOfMethodHierarchy && symbol instanceof MethodSymbol) {
-      // Returns an ordered LinkedHashSet
-      Set<MethodSymbol> superMethods =
-          ASTHelpers.findSuperMethods((MethodSymbol) symbol, state.getTypes());
-      for (MethodSymbol superMethod : superMethods) {
-        // The last method in the set will be the top-level declaration
-        symbol = superMethod;
-      }
-    }
     AnnotationMirror annotation = findAnnotatedApi(symbol);
     if (annotation == null) {
       return NO_MATCH;
+    }
+    if (requireAnnotationOnMethodHierarchy && symbol instanceof MethodSymbol) {
+      Set<MethodSymbol> superMethods =
+              ASTHelpers.findSuperMethods((MethodSymbol) symbol, state.getTypes());
+      for (MethodSymbol superMethod : superMethods) {
+        AnnotationMirror superAnnotation = findAnnotatedApi(superMethod);
+        if (superAnnotation == null) {
+          return NO_MATCH;
+        }
+      }
     }
     return describe(tree, annotation);
   }

--- a/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
@@ -38,6 +38,7 @@ public final class InternalChecker extends AnnotationChecker {
 
   public InternalChecker() {
     super("io.grpc.Internal");
+    checkTopOfMethodHierarchy = true;
   }
 
   @Override

--- a/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/InternalChecker.java
@@ -37,8 +37,7 @@ import javax.lang.model.element.AnnotationMirror;
 public final class InternalChecker extends AnnotationChecker {
 
   public InternalChecker() {
-    super("io.grpc.Internal");
-    checkTopOfMethodHierarchy = true;
+    super("io.grpc.Internal", true);
   }
 
   @Override


### PR DESCRIPTION
Intended to address https://github.com/grpc/grpc-java-api-checker/issues/13

I couldn't find a good way to include coverage for this in the unit tests, as the current test setup doesn't allow defining a class that extends any `@Internal` classes, as is done in the gRPC library with `ManagedChannelBuilder` -> `AbstractManagedChannelBuilder` -> `NettyChannelBuilder`. But I tested this manually with the gRPC examples code, and also verified that this works if the top-level declaration comes from a public interface rather than an abstract class.