### PR TITLE
bump version to 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <groupId>io.grpc</groupId>
   <artifactId>grpc-java-api-checker</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
 
   <name>grpc-java-api-checker</name>
   <description>An Error Prone plugin that checks for usages of grpc-java experimental or internal APIs.</description>


### PR DESCRIPTION
I think we should do a new release now that #14 is in. @jyane, do you think we should release 1.1.0 (as in this PR) or do a 1.0.1 instead?