### PR TITLE
Update example dependencies

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,7 +2,7 @@ java_library(
     name = "example",
     srcs = glob(["src/main/java/com/example/*.java"]),
     deps = [
-      "@grpc_java//core",
+      "@io_grpc_grpc_java//core",
     ],
     plugins = [
       ":io_grpc_grpc_java_api_checker_plugin",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,12 +1,12 @@
 workspace(name = "example")
 
 http_archive(
-    name = "grpc_java",
-    strip_prefix = "grpc-java-1.10.0",
-    urls = ["https://github.com/grpc/grpc-java/archive/v1.10.0.zip"],
+    name = "io_grpc_grpc_java",
+    strip_prefix = "grpc-java-1.17.1",
+    urls = ["https://github.com/grpc/grpc-java/archive/v1.17.1.zip"],
 )
 
-load("@grpc_java//:repositories.bzl", "grpc_java_repositories")
+load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,3 +1,5 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+
 buildscript {
     repositories {
         mavenCentral()
@@ -6,14 +8,12 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
-        classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.6'
     }
 }
 
 apply plugin: 'java'
 apply plugin: 'net.ltgt.errorprone'
-apply plugin: 'net.ltgt.apt'
 
 repositories {
     mavenLocal()
@@ -21,15 +21,17 @@ repositories {
 }
 
 dependencies {
-    compile 'io.grpc:grpc-core:1.10.0'
-    apt 'io.grpc:grpc-java-api-checker:1.1.0'
-}
-
-configurations.errorprone {
-    resolutionStrategy.force 'com.google.errorprone:error_prone_core:2.2.0'
+    compile 'io.grpc:grpc-core:1.17.1'
+    annotationProcessor 'io.grpc:grpc-java-api-checker:1.1.0'
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
+    errorprone 'com.google.errorprone:error_prone_core:2.3.2'
 }
 
 compileJava {
     // you can specify the settings
-    options.compilerArgs += ["-XepDisableAllChecks", "-Xep:GrpcInternal:ERROR", "-Xep:GrpcExperimentalApi:ERROR"]
+    options.errorprone {
+      disableAllChecks = true
+      check("GrpcExperimentalApi", CheckSeverity.ERROR)
+      check("GrpcInternal", CheckSeverity.ERROR)
+    }
 }

--- a/examples/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
-      <version>1.10.0</version>
+      <version>1.17.1</version>
     </dependency>
   </dependencies>
 
@@ -49,7 +49,7 @@
           <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_core</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.2</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
1. Update gradle to 4.9
  Same as grpc-java, see also: grpc/grpc-java@94b2618

2. Update error-prone to 2.3.2

3. Update grpc to 1.17.1
  Add a grpc project name prefix to `io_grpc_grpc_java`