### PR TITLE
travis.yml: Avoid repository.apache.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 
 sudo: false
 
+before_install:
+  - rm ~/.m2/settings.xml || true # Avoid repository.apache.org, which has QPS limits and is useless
+
 cache:
   directories:
   - "$HOME/.m2"


### PR DESCRIPTION
We think it is breaking a junit snapshot download. A junit snapshot download is
weird and we don't know how it is breaking it, but repository.apache.org
has caused us problems before so remove it now anyway.
https://github.com/grpc/grpc-java/commit/3b578abf998eb59cc494bd850385b796239ee43e