### PR TITLE
Use JDK 8 to fix travis failure for maven test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 
 sudo: false
 
+jdk:
+  - openjdk8
+
 cache:
   directories:
   - "$HOME/.m2"


### PR DESCRIPTION
There was a [known issue](https://github.com/junit-team/junit4/issues/1513) that maven test with surefire 2.20.1 fails for JDK 11, and travis is now using JDK 11 by default.