### PR TITLE
travis: Avoid caching Maven configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 
 cache:
   directories:
-  - "$HOME/.m2"
+  - "$HOME/.m2/repository"
 
 notifications:
   email: false


### PR DESCRIPTION
An older version of Travis's Maven configuration was cached which eventually
caused builds to fail as it had referenced http://repo1.maven.org which is now
disallowed.