### PR TITLE
Upgrade to ErrorProne 2.4.0 (and others) to avoid JUnit 3.13-SNAPSHOT dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <errorprone.version>2.2.0</errorprone.version>
+    <errorprone.version>2.4.0</errorprone.version>
     <javac.version>9+181-r4173-1</javac.version>
   </properties>
 
@@ -65,27 +65,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <version>1.0-rc3</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>23.0</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
       <version>${errorprone.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.0-rc7</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>27.1-jre</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -93,6 +93,18 @@
       <artifactId>error_prone_test_helpers</artifactId>
       <version>${errorprone.version}</version>
       <scope>test</scope>
+    </dependency>
+
+    <!-- force version of transitive dependencies to avoid requireUpperBoundDeps violation -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>2.10.0</version>
     </dependency>
   </dependencies>
 
@@ -125,6 +137,24 @@
         <configuration>
             <argLine>-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</argLine>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireUpperBoundDeps/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Added requireUpperBoundDeps to verify new versions. Upgraded Guava and JUnit to
avoid downgrading transitive dependencies. Upgraded auto-service as otherwise
javac crashed with "java.lang.ClassCastException: com.sun.tools.javac.util.List
cannot be cast to javax.lang.model.type.DeclaredType".