### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <errorprone.version>2.4.0</errorprone.version>
+    <errorprone.version>2.10.0</errorprone.version>
     <javac.version>9+181-r4173-1</javac.version>
   </properties>
 
@@ -65,27 +65,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <version>1.1.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
       <version>${errorprone.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <version>1.0-rc7</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>27.1-jre</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -95,16 +89,11 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- force version of transitive dependencies to avoid requireUpperBoundDeps violation -->
+    <!-- upgrade version of transitive dependencies to avoid requireUpperBoundDeps violation -->
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker-qual</artifactId>
-      <version>2.10.0</version>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.7.4</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
+++ b/src/main/java/io/grpc/annotations/checkers/AnnotationChecker.java
@@ -16,7 +16,6 @@
 
 package io.grpc.annotations.checkers;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.errorprone.matchers.Description.NO_MATCH;
 
 import com.google.errorprone.VisitorState;
@@ -48,7 +47,10 @@ abstract class AnnotationChecker extends BugChecker implements IdentifierTreeMat
   }
 
   AnnotationChecker(String annotationType, boolean requireAnnotationOnMethodHierarchy) {
-    this.annotationType = checkNotNull(annotationType, "annotationType");
+    if (annotationType == null) {
+      throw new NullPointerException("annotationType");
+    }
+    this.annotationType = annotationType;
     this.requireAnnotationOnMethodHierarchy = requireAnnotationOnMethodHierarchy;
   }
 


### PR DESCRIPTION
Guava was used by a single checkNotNull() call site, so the dependency was removed instead of upgraded.