### PR TITLE
Replace a build badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grpc-java-api-checker
 
-[![GitHub Actions Testing](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml/badge.svg)](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml)
+[![GitHub Actions Testing](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml/badge.svg)](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml?branch=master)
 
 An Error Prone plugin that checks for usages of grpc-java APIs that are annotated with `@ExperimentalApi` or `@Internal`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grpc-java-api-checker
 
-[![GitHub Actions Testing](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml/badge.svg)](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml?branch=master)
+[![GitHub Actions Testing](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml/badge.svg?branch=master)](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml?branch=master)
 
 An Error Prone plugin that checks for usages of grpc-java APIs that are annotated with `@ExperimentalApi` or `@Internal`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # grpc-java-api-checker
 
-[![Build Status](https://travis-ci.org/grpc/grpc-java-api-checker.svg?branch=master)](https://travis-ci.org/grpc/grpc-java-api-checker)
+[![GitHub Actions Testing](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml/badge.svg)](https://github.com/grpc/grpc-java-api-checker/actions/workflows/testing.yml)
 
 An Error Prone plugin that checks for usages of grpc-java APIs that are annotated with `@ExperimentalApi` or `@Internal`.
 


### PR DESCRIPTION
Since Travis CI is no longer used in this repo, this should be replaced with the GitHub Actions badge.

===
I have noticed that the same issue is in grpc/grpc-java, I will create a CL to fix it once this was submited.